### PR TITLE
Used the passed in version when tagging

### DIFF
--- a/lib/radius/toolbelt/release_helpers.rb
+++ b/lib/radius/toolbelt/release_helpers.rb
@@ -5,8 +5,8 @@ module Radius
     module ReleaseHelpers
 
       def tag_version(ver)
-        unless system("git tag v#{agvtool_version}")
-          fail "Error: the tag v#{agvtool_version} already exists on this repo."
+        unless system("git tag v#{ver}")
+          fail "Error: the tag v#{ver} already exists on this repo."
         end
       end
 


### PR DESCRIPTION
It was getting dropped on the floor and we were calling `agvtool` in the current repo. Which doesn't work for a workspace-only repo.
