### PR TITLE
Relaxes version constraints on ruby version and rake version

### DIFF
--- a/lib/radius/toolbelt/version.rb
+++ b/lib/radius/toolbelt/version.rb
@@ -1,5 +1,5 @@
 module Radius
   module Toolbelt
-    VERSION = "0.0.9"
+    VERSION = "0.0.10"
   end
 end

--- a/radius-toolbelt.gemspec
+++ b/radius-toolbelt.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w[ lib ]
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0'
 
-  spec.add_dependency "rake", "~> 12.0"
+  spec.add_dependency "rake", ">= 12.0"
   spec.add_dependency "launchy"
   spec.add_dependency "octokit"
   spec.add_dependency "mime-types"


### PR DESCRIPTION
In order to update `nautilus` to a newer ruby version, we need to first relax the requirements for `ruby` and `rake`

Because this gem is used elsewhere, we're not going to `~>` pin it but just do an `>=`. 